### PR TITLE
Fixing bug in ie

### DIFF
--- a/css/visualization_styles.css
+++ b/css/visualization_styles.css
@@ -33,6 +33,7 @@ circle {
 #map {
   border: 2px solid #0A080D;
   box-shadow: 0 0 12px #000;
+  overflow: hidden;
 }
 
 .hidden { 


### PR DESCRIPTION
The map display was drawing beyond the bounds of the svg container. This clips it appropriately.
